### PR TITLE
Add cover seeking to GoWithinRangeOfHostile

### DIFF
--- a/Source/SearchAndDestroy/JobGiver_AIGoWithinRangeOfHostile.cs
+++ b/Source/SearchAndDestroy/JobGiver_AIGoWithinRangeOfHostile.cs
@@ -48,9 +48,30 @@ namespace SearchAndDestroy
             }
 
             if (targetA == null)
+            {
                 return null;
+            }
 
-            var job = JobMaker.MakeJob(JobDefOf.Goto, (LocalTargetInfo)targetA);
+            IntVec3 destCell = targetA.Position;
+
+            Verb verb = pawn.TryGetAttackVerb(targetA, false);
+            if (verb != null)
+            {
+                CastPositionRequest request = new CastPositionRequest
+                {
+                    caster = pawn,
+                    target = (LocalTargetInfo)targetA,
+                    verb = verb,
+                    maxRangeFromTarget = verb.verbProps.range,
+                    wantCoverFromTarget = true
+                };
+                if (CastPositionFinder.TryFindCastPosition(request, out IntVec3 coverPos))
+                {
+                    destCell = coverPos;
+                }
+            }
+
+            var job = JobMaker.MakeJob(JobDefOf.Goto, destCell);
             job.checkOverrideOnExpire = true;
             job.collideWithPawns = true;
             job.expiryInterval = 30;


### PR DESCRIPTION
## Summary
- improve `JobGiver_GoWithinRangeOfHostile.TryGiveJob` to use `CastPositionFinder` to find a cover position from the chosen target
- still falls back to going directly to the target if no cover can be found

## Testing
- `dotnet build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685fc0b01b6883289cc0b7c1833e5556